### PR TITLE
Make tcpb initial account creation re-entrant

### DIFF
--- a/pkg/neobench/builtin/tpcb_like.go
+++ b/pkg/neobench/builtin/tpcb_like.go
@@ -88,7 +88,7 @@ MERGE (t:Teller {tid: tellerId}) SET t.balance = 0
 	batchSize := int64(5000)
 	numBatches := numAccounts / batchSize
 	for batchNo := int64(0); batchNo <= numBatches; batchNo++ {
-		startAccount := max(existingAccountNum, batchSize*batchNo+1)
+		startAccount := max(existingAccountNum, batchSize*batchNo) + 1
 		endAccount := min(numAccounts, startAccount+batchSize) - 1
 		if endAccount <= startAccount {
 			continue


### PR DESCRIPTION
Currently it tries to create an account with the same id as the highest-id existing account which violates a constraint. It should try and create the _next_ account!